### PR TITLE
Update index.mdx by fixing links to download cli

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -59,7 +59,7 @@ Next checkout
 
 [api-reference]: /docs/api/
 [cli-guide]: /docs/guides/cli-overview/
-[linux-arm]: http://openline.sh/openline-linux-arm.tar.gz
-[linux-x64]: http://openline.sh/openline-linux-x64.tar.gz
-[mac-arm]: http://openline.sh/openline-darwin-arm.tar.gz
-[mac-x64]: http://openline.sh/openline-darwin-x64.tar.gz
+[linux-arm]: http://openline.sh/channels/stable/openline-linux-arm.tar.gz
+[linux-x64]: http://openline.sh/channels/stable/openline-linux-x64.tar.gz
+[mac-arm]: http://openline.sh/channels/stable/openline-darwin-arm64.tar.gz
+[mac-x64]: http://openline.sh/channels/stable/openline-darwin-x64.tar.gz


### PR DESCRIPTION
Links to the openline-cli were not correct. By looking at the install.sh script I was able to find them and updated the docs site.